### PR TITLE
v2.0.1: Flag as last version compatible with Polly v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Polly.Caching.Serialization.Json change log
 
+## 2.0.1
+- No functional changes
+- Indicate compatibility with Polly &gt;= v6.0.1 and &lt; v7
+
 ## 2.0.0
 
 - Reference Polly v6.0.1

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 2.0.0
+next-version: 2.0.1

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Polly is a member of the [.NET Foundation](https://www.dotnetfoundation.org/abou
 
 Polly.Caching.Serialization.Json supports .NET Standard 1.1 and .NET Standard 2.0.
 
-## Dependencies
+## Versions and Dependencies
 
-Polly.Caching.Serialization.Json requires:
+Polly.Caching.Serialization.Json &gt;=v2.0 and &lt;v3 requires:
 
-+ [Polly](https://github.com/App-vNext/Polly) v6.0.1 or above
++ [Polly](https://nuget.org/packages/polly) >= v6.0.1 and &lt;v7.
 + [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) v11.0.2 or above
 
 # How to use the Polly.Caching.Serialization.Json plugin

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 [assembly: AssemblyProduct("Polly.Caching.Serialization.Json")]
 [assembly: AssemblyCompany("App vNext")]
 [assembly: AssemblyDescription("Polly.Caching.Serialization.Json is a Newtonsoft.Json serialization plug-in for the Polly CachePolicy.  Polly is a library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.")]
-[assembly: AssemblyCopyright("Copyright (c) 2018, App vNext")]
+[assembly: AssemblyCopyright("Copyright (c) 2019, App vNext")]
 [assembly: CLSCompliant(false)] // Because not all of Newtonsoft.Json, on which we depend, is CLSCompliant.
 
 #if DEBUG

--- a/src/Polly.Caching.Serialization.Json.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Serialization.Json.NetStandard11/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Serialization.Json")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]
 
 [assembly: InternalsVisibleTo("Polly.Caching.Serialization.Json.NetStandard11.Specs")]

--- a/src/Polly.Caching.Serialization.Json.NetStandard20/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Serialization.Json.NetStandard20/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Serialization.Json")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]
 
 [assembly: InternalsVisibleTo("Polly.Caching.Serialization.Json.NetStandard20.Specs")]

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -13,6 +13,11 @@
     <tags>Polly Cache Caching Cache-aside serialization Json</tags>
     <copyright>Copyright © 2019, App vNext</copyright>
     <releaseNotes>
+     2.0.1
+     ---------------------
+     - No functional changes
+     - Indicate compatibility with Polly &gt;= v6.0.1 and &lt; v7
+
      2.0.0 (first nuget release)
      ---------------------
      - Supports NetStandard1.1 and NetStandard2.0
@@ -24,11 +29,11 @@
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="Newtonsoft.Json" version="11.0.2" />
-        <dependency id="Polly" version="6.0.1" />
+        <dependency id="Polly" version="[6.0.1,7)" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Newtonsoft.Json" version="11.0.2" />
-        <dependency id="Polly" version="6.0.1" />
+        <dependency id="Polly" version="[6.0.1,7)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -27,7 +27,6 @@
         <dependency id="Polly" version="6.0.1" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="NETStandard.Library" version="2.0.0" />
         <dependency id="Newtonsoft.Json" version="11.0.2" />
         <dependency id="Polly" version="6.0.1" />
       </group>

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -7,7 +7,7 @@
       Polly.Caching.Serialization.Json is a plug-in for the .NET OSS resilience library Polly, supporting serialization to and from Json using Newtonsoft.Json
     </description>
     <language>en-US</language>
-    <licenseUrl>https://raw.github.com/App-vNext/Polly/master/LICENSE.txt</licenseUrl>
+    <license type="expression">BSD-3-Clause</license>
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly.Caching.Serialization.Json</projectUrl>
     <tags>Polly Cache Caching Cache-aside serialization Json</tags>

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly.Caching.Serialization.Json</projectUrl>
     <tags>Polly Cache Caching Cache-aside serialization Json</tags>
-    <copyright>Copyright © 2018, App vNext</copyright>
+    <copyright>Copyright © 2019, App vNext</copyright>
     <releaseNotes>
      2.0.0 (first nuget release)
      ---------------------


### PR DESCRIPTION
Create a v2.0.1, flagged as the last version compatible with Polly v6.*

+ Also fixes #11 : License tag element in nuspec
+ Also fixes #9 : NetStandard 2.0 dependencies