### PR TITLE
Version 3.0.0: For compatibility with (forthcoming) Polly v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Polly.Caching.Serialization.Json change log
 
+## 3.0.0
+- Allow serialization of default(TResult) for caching
+- Compatible with Polly &gt;= v7
+
 ## 2.0.1
 - No functional changes
 - Indicate compatibility with Polly &gt;= v6.0.1 and &lt; v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Polly.Caching.Serialization.Json change log
 
+## 2.0.1
+- No functional changes
+- Indicate compatibility with Polly &gt;= v6.0.1 and &lt; v7
+
 ## 2.0.0
 
 - Reference Polly v6.0.1

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 2.0.0
+next-version: 2.0.1

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 2.0.1
+next-version: 3.0.0

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Polly is a member of the [.NET Foundation](https://www.dotnetfoundation.org/abou
 
 Polly.Caching.Serialization.Json supports .NET Standard 1.1 and .NET Standard 2.0.
 
-## Dependencies
+## Versions and Dependencies
 
-Polly.Caching.Serialization.Json requires:
+Polly.Caching.Serialization.Json &gt;=v2.0 and &lt;v3 requires:
 
-+ [Polly](https://github.com/App-vNext/Polly) v6.0.1 or above
++ [Polly](https://nuget.org/packages/polly) >= v6.0.1 and &lt;v7.
 + [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) v11.0.2 or above
 
 # How to use the Polly.Caching.Serialization.Json plugin

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Polly.Caching.Serialization.Json supports .NET Standard 1.1 and .NET Standard 2.
 
 ## Versions and Dependencies
 
+Polly.Caching.Serialization.Json &gt;=v3.0 requires:
+
++ [Polly](https://nuget.org/packages/polly) >= v7.0.0.
++ [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) v11.0.2 or above
+
 Polly.Caching.Serialization.Json &gt;=v2.0 and &lt;v3 requires:
 
 + [Polly](https://nuget.org/packages/polly) >= v6.0.1 and &lt;v7.
@@ -79,6 +84,7 @@ For details of changes by release see the [change log](CHANGELOG.md).
 
 * [@reisenberger](https://github.com/reisenberger) - Polly Json serializer using Newtonsoft.Json
 * [@seanfarrow](https://github.com/seanfarrow) and [@reisenberger](https://github.com/reisenberger) - Caching and serialization architecture in the main Polly repo
+* [@reisenberger](https://github.com/reisenberger) - Update to Polly v7.0.0
 
 # Instructions for Contributing
 

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 [assembly: AssemblyProduct("Polly.Caching.Serialization.Json")]
 [assembly: AssemblyCompany("App vNext")]
 [assembly: AssemblyDescription("Polly.Caching.Serialization.Json is a Newtonsoft.Json serialization plug-in for the Polly CachePolicy.  Polly is a library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.")]
-[assembly: AssemblyCopyright("Copyright (c) 2018, App vNext")]
+[assembly: AssemblyCopyright("Copyright (c) 2019, App vNext")]
 [assembly: CLSCompliant(false)] // Because not all of Newtonsoft.Json, on which we depend, is CLSCompliant.
 
 #if DEBUG

--- a/src/Polly.Caching.Serialization.Json.NetStandard11.Specs/Polly.Caching.Serialization.Json.NetStandard11.Specs.csproj
+++ b/src/Polly.Caching.Serialization.Json.NetStandard11.Specs/Polly.Caching.Serialization.Json.NetStandard11.Specs.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="Polly" Version="7.0.0" />
 
   </ItemGroup>
   <ItemGroup>

--- a/src/Polly.Caching.Serialization.Json.NetStandard11/Polly.Caching.Serialization.Json.NetStandard11.csproj
+++ b/src/Polly.Caching.Serialization.Json.NetStandard11/Polly.Caching.Serialization.Json.NetStandard11.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="Polly" Version="7.0.0" />
   </ItemGroup>
   <Import Project="..\Polly.Caching.Serialization.Json.Shared\Polly.Caching.Serialization.Json.Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Polly.Caching.Serialization.Json.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Serialization.Json.NetStandard11/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Serialization.Json")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]
 
 [assembly: InternalsVisibleTo("Polly.Caching.Serialization.Json.NetStandard11.Specs")]

--- a/src/Polly.Caching.Serialization.Json.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Serialization.Json.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Serialization.Json")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.1.0")]
-[assembly: AssemblyInformationalVersion("2.0.1.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyInformationalVersion("3.0.0.0")]
 
 [assembly: InternalsVisibleTo("Polly.Caching.Serialization.Json.NetStandard11.Specs")]

--- a/src/Polly.Caching.Serialization.Json.NetStandard20.Specs/Polly.Caching.Serialization.Json.NetStandard20.Specs.csproj
+++ b/src/Polly.Caching.Serialization.Json.NetStandard20.Specs/Polly.Caching.Serialization.Json.NetStandard20.Specs.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="Polly" Version="7.0.0" />
 
   </ItemGroup>
   <ItemGroup>

--- a/src/Polly.Caching.Serialization.Json.NetStandard20/Polly.Caching.Serialization.Json.NetStandard20.csproj
+++ b/src/Polly.Caching.Serialization.Json.NetStandard20/Polly.Caching.Serialization.Json.NetStandard20.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="Polly" Version="7.0.0" />
   </ItemGroup>
   <Import Project="..\Polly.Caching.Serialization.Json.Shared\Polly.Caching.Serialization.Json.Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Polly.Caching.Serialization.Json.NetStandard20/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Serialization.Json.NetStandard20/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Serialization.Json")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]
 
 [assembly: InternalsVisibleTo("Polly.Caching.Serialization.Json.NetStandard20.Specs")]

--- a/src/Polly.Caching.Serialization.Json.NetStandard20/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Serialization.Json.NetStandard20/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Serialization.Json")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.1.0")]
-[assembly: AssemblyInformationalVersion("2.0.1.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyInformationalVersion("3.0.0.0")]
 
 [assembly: InternalsVisibleTo("Polly.Caching.Serialization.Json.NetStandard20.Specs")]

--- a/src/Polly.Caching.Serialization.Json.Shared/JsonSerializer.cs
+++ b/src/Polly.Caching.Serialization.Json.Shared/JsonSerializer.cs
@@ -27,7 +27,7 @@ namespace Polly.Caching.Serialization.Json
         /// <returns>The deserialized object</returns>
         public TResult Deserialize(string objectToDeserialize)
         {
-            return String.IsNullOrEmpty(objectToDeserialize) ? default(TResult) : JsonConvert.DeserializeObject<TResult>(objectToDeserialize, _serializerSettings);
+            return JsonConvert.DeserializeObject<TResult>(objectToDeserialize, _serializerSettings);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Polly.Caching.Serialization.Json
         /// <returns>The serialized object</returns>
         public string Serialize(TResult objectToSerialize)
         {
-            return objectToSerialize == null || objectToSerialize.Equals(default(TResult)) ? null : JsonConvert.SerializeObject(objectToSerialize, _serializerSettings);
+            return JsonConvert.SerializeObject(objectToSerialize, _serializerSettings);
         }
     }
 }

--- a/src/Polly.Caching.Serialization.Json.SharedSpecs/JsonSerializerSpecs.cs
+++ b/src/Polly.Caching.Serialization.Json.SharedSpecs/JsonSerializerSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 using Polly.Caching.Serialization.Json;
@@ -7,6 +8,11 @@ namespace Polly.Specs.Caching.Serialization.Json
 {
     public class JsonSerializerSpecs
     {
+        readonly Newtonsoft.Json.JsonSerializerSettings StandardSettings = new Newtonsoft.Json.JsonSerializerSettings()
+        {
+            StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml
+        };
+
         #region Configuration
 
         [Fact]
@@ -34,12 +40,7 @@ namespace Polly.Specs.Caching.Serialization.Json
         [Fact]
         public void Should_serialize_using_configured_JsonSerializerSettings()
         {
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings()
-            {
-                StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml
-            };
-
-            JsonSerializer<SampleClass> serializer = new JsonSerializer<SampleClass>(settings);
+            JsonSerializer<SampleClass> serializer = new JsonSerializer<SampleClass>(StandardSettings);
 
             SampleClass objectToSerialize = new SampleClass()
             {
@@ -52,23 +53,6 @@ namespace Polly.Specs.Caching.Serialization.Json
             serialized.Should().Be("{\"StringProperty\":\"\\u003chtml\\u003e\\u003c/html\\u003e\",\"IntProperty\":1}");
         }
 
-        [Fact]
-        public void Should_serialize_default_value_to_null()
-        {
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings()
-            {
-                StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml
-            };
-
-            JsonSerializer<SampleClass> serializer = new JsonSerializer<SampleClass>(settings);
-
-            SampleClass objectToSerialize = default(SampleClass);
-
-            string serialized = serializer.Serialize(objectToSerialize);
-
-            serialized.Should().BeNull();
-        }
-
         #endregion
 
         #region Deserialize
@@ -76,12 +60,7 @@ namespace Polly.Specs.Caching.Serialization.Json
         [Fact]
         public void Should_deserialize_using_configured_JsonSerializerSettings()
         {
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings()
-            {
-                StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml
-            };
-
-            JsonSerializer<SampleClass> serializer = new JsonSerializer<SampleClass>(settings);
+            JsonSerializer<SampleClass> serializer = new JsonSerializer<SampleClass>(StandardSettings);
 
             string serialized = "{\"StringProperty\":\"\\u003chtml\\u003e\\u003c/html\\u003e\",\"IntProperty\":1}";
 
@@ -95,45 +74,144 @@ namespace Polly.Specs.Caching.Serialization.Json
         }
 
         [Fact]
-        public void Should_deserialize_null_to_default_value()
+        public void Throws_on_deserialize_null()
         {
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings()
-            {
-                StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml
-            };
+            JsonSerializer<object> serializer = new JsonSerializer<object>(StandardSettings);
 
-            JsonSerializer<SampleClass> serializer = new JsonSerializer<SampleClass>(settings);
+            Action deserializeNull = () => serializer.Deserialize(null);
 
-            string serialized = null;
-
-            SampleClass deserialized = serializer.Deserialize(serialized);
-
-            deserialized.Should().BeNull();
-        }
-
-        [Fact]
-        public void Should_deserialize_empty_to_default_value()
-        {
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings()
-            {
-                StringEscapeHandling = Newtonsoft.Json.StringEscapeHandling.EscapeHtml
-            };
-
-            JsonSerializer<SampleClass> serializer = new JsonSerializer<SampleClass>(settings);
-
-            string serialized = String.Empty;
-
-            SampleClass deserialized = serializer.Deserialize(serialized);
-
-            deserialized.Should().BeNull();
+            deserializeNull.ShouldThrow<ArgumentNullException>();
         }
 
         #endregion
+
+        #region Round-trip
+
+        [Theory]
+        [MemberData(nameof(SampleClassData))]
+        public void Should_roundtrip_all_variants_of_reference_type(SampleClass testValue)
+        {
+            JsonSerializer<SampleClass> serializer = new JsonSerializer<SampleClass>(StandardSettings);
+
+            serializer.Deserialize(serializer.Serialize(testValue)).ShouldBeEquivalentTo(testValue);
+        }
+
+        public static TheoryData<SampleClass> SampleClassData =>
+            new TheoryData<SampleClass>
+            {
+               new SampleClass(),
+               new SampleClass()
+               {
+                   StringProperty = "<html></html>",
+                   IntProperty = 1
+               },
+               (SampleClass)null,
+               default(SampleClass)
+            };
+
+        public class SampleClass
+        {
+            public string StringProperty { get; set; }
+            public int IntProperty { get; set; }
+        }
+
+        [Theory]
+        [MemberData(nameof(SampleStringData))]
+        public void Should_roundtrip_all_variants_of_string(String testValue)
+        {
+            JsonSerializer<String> serializer = new JsonSerializer<String>(StandardSettings);
+
+            serializer.Deserialize(serializer.Serialize(testValue)).Should().Be(testValue);
+        }
+
+        public static TheoryData<String> SampleStringData =>
+            new TheoryData<String>
+            {
+                "some string",
+                "",
+                null,
+                default(string),
+                "null"
+            };
+
+        [Theory]
+        [MemberData(nameof(SampleNumericData))]
+        public void Should_roundtrip_all_variants_of_numeric(int testValue)
+        {
+            JsonSerializer<int> serializer = new JsonSerializer<int>(StandardSettings);
+
+            serializer.Deserialize(serializer.Serialize(testValue)).Should().Be(testValue);
+        }
+
+
+        public static TheoryData<int> SampleNumericData =>
+            new TheoryData<int>
+            {
+               -1,
+               0,
+               1,
+               default(int)
+            };
+
+        [Theory]
+        [MemberData(nameof(SampleEnumData))]
+        public void Should_roundtrip_all_variants_of_enum(SampleEnum testValue)
+        {
+            JsonSerializer<SampleEnum> serializer = new JsonSerializer<SampleEnum>(StandardSettings);
+
+            serializer.Deserialize(serializer.Serialize(testValue)).Should().Be(testValue);
+        }
+
+
+        public static TheoryData<SampleEnum> SampleEnumData =>
+            new TheoryData<SampleEnum>
+            {
+              SampleEnum.FirstValue,
+              SampleEnum.SecondValue,
+              default(SampleEnum),
+            };
+
+        public enum SampleEnum
+        {
+            FirstValue,
+            SecondValue,
+        }
+
+        [Theory]
+        [MemberData(nameof(SampleBoolData))]
+        public void Should_roundtrip_all_variants_of_bool(bool testValue)
+        {
+            JsonSerializer<bool> serializer = new JsonSerializer<bool>(StandardSettings);
+
+            serializer.Deserialize(serializer.Serialize(testValue)).Should().Be(testValue);
+        }
+
+        public static TheoryData<bool> SampleBoolData =>
+            new TheoryData<bool>
+            {
+               true,
+               false,
+               default(bool),
+            };
+
+        [Theory]
+        [MemberData(nameof(SampleNullableBoolData))]
+        public void Should_roundtrip_all_variants_of_nullable_bool(bool? testValue)
+        {
+            JsonSerializer<bool?> serializer = new JsonSerializer<bool?>(StandardSettings);
+
+            serializer.Deserialize(serializer.Serialize(testValue)).Should().Be(testValue);
+        }
+
+        public static TheoryData<bool?> SampleNullableBoolData =>
+            new TheoryData<bool?>
+            {
+                true,
+                false,
+                null,
+                default(bool?),
+            };
+        #endregion
     }
 
-    internal class SampleClass
-    {
-        public string StringProperty { get; set; }
-        public int IntProperty { get; set; }
-    }
 }

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -34,6 +34,7 @@
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="Newtonsoft.Json" version="11.0.2" />
+        <dependency id="System.ValueTuple" version="4.5.0" />
         <dependency id="Polly" version="7.0.0" />
       </group>
       <group targetFramework="netstandard2.0">

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -13,6 +13,11 @@
     <tags>Polly Cache Caching Cache-aside serialization Json</tags>
     <copyright>Copyright © 2019, App vNext</copyright>
     <releaseNotes>
+     2.0.1
+     ---------------------
+     - No functional changes
+     - Indicate compatibility with Polly &gt;= v6.0.1 and &lt; v7
+
      2.0.0 (first nuget release)
      ---------------------
      - Supports NetStandard1.1 and NetStandard2.0
@@ -24,11 +29,11 @@
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="Newtonsoft.Json" version="11.0.2" />
-        <dependency id="Polly" version="6.0.1" />
+        <dependency id="Polly" version="[6.0.1,7)" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Newtonsoft.Json" version="11.0.2" />
-        <dependency id="Polly" version="6.0.1" />
+        <dependency id="Polly" version="[6.0.1,7)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -13,6 +13,11 @@
     <tags>Polly Cache Caching Cache-aside serialization Json</tags>
     <copyright>Copyright © 2019, App vNext</copyright>
     <releaseNotes>
+     3.0.0
+     ---------------------
+     - Allow serialization of default(TResult) for caching
+     - Compatible with Polly &gt;= v7
+
      2.0.1
      ---------------------
      - No functional changes
@@ -29,11 +34,11 @@
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="Newtonsoft.Json" version="11.0.2" />
-        <dependency id="Polly" version="[6.0.1,7)" />
+        <dependency id="Polly" version="7.0.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Newtonsoft.Json" version="11.0.2" />
-        <dependency id="Polly" version="[6.0.1,7)" />
+        <dependency id="Polly" version="7.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -27,7 +27,6 @@
         <dependency id="Polly" version="6.0.1" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="NETStandard.Library" version="2.0.0" />
         <dependency id="Newtonsoft.Json" version="11.0.2" />
         <dependency id="Polly" version="6.0.1" />
       </group>

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -7,7 +7,7 @@
       Polly.Caching.Serialization.Json is a plug-in for the .NET OSS resilience library Polly, supporting serialization to and from Json using Newtonsoft.Json
     </description>
     <language>en-US</language>
-    <licenseUrl>https://raw.github.com/App-vNext/Polly/master/LICENSE.txt</licenseUrl>
+    <license type="expression">BSD-3-Clause</license>
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly.Caching.Serialization.Json</projectUrl>
     <tags>Polly Cache Caching Cache-aside serialization Json</tags>

--- a/src/Polly.Caching.Serialization.Json.nuspec
+++ b/src/Polly.Caching.Serialization.Json.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly.Caching.Serialization.Json</projectUrl>
     <tags>Polly Cache Caching Cache-aside serialization Json</tags>
-    <copyright>Copyright © 2018, App vNext</copyright>
+    <copyright>Copyright © 2019, App vNext</copyright>
     <releaseNotes>
      2.0.0 (first nuget release)
      ---------------------


### PR DESCRIPTION
Fixes #10 : Compatibility with Polly v7.0.0

_Build will break / not for merge prior to the public release of Polly v7.0.0_ ( pre-release tested via private feed of https://github.com/App-vNext/Polly/pull/559 )